### PR TITLE
Fix table creation statement

### DIFF
--- a/churchtools-wpcalendarsync.php
+++ b/churchtools-wpcalendarsync.php
@@ -152,7 +152,7 @@ function ctwpsync_initplugin()
 {
     global $wpdb;
     $table_name = $wpdb->prefix.'ctwpsync_mapping';
-    $sql = "CREATE TABLE IF NOT EXISTS ".$table_name."(
+    $sql = "CREATE TABLE ".$table_name." (
             id mediumint(9) NOT NULL AUTO_INCREMENT,
             ct_id mediumint(9) NOT NULL,
             ct_repeating mediumint(9),


### PR DESCRIPTION
According to [this comment](https://developer.wordpress.org/reference/functions/dbdelta/#comment-5413), `CREATE` statements should not use `IF NOT EXISTS` since it messes up `dbDelta()`s regex parsing.

That same parsing also does not like if the opening bracket is attached to the table name without a space.